### PR TITLE
passed maxgap=-1 default arg to gr.findoverlaps

### DIFF
--- a/R/gUtils.R
+++ b/R/gUtils.R
@@ -2599,7 +2599,7 @@ gr.nochr = function(gr) {
 #' @param ... Additional arguments sent to \code{IRanges::findOverlaps}.
 #' @return \code{GRanges} pile of the intersection regions, with \code{query.id} and \code{subject.id} marking sources
 #' @export
-gr.findoverlaps = function(query, subject, ignore.strand = TRUE, first = FALSE, qcol = NULL, scol = NULL, type = 'any', by = NULL, return.type = 'same', max.chunk = 1e13, verbose = FALSE, mc.cores = 1, ...)
+gr.findoverlaps = function(query, subject, ignore.strand = TRUE, first = FALSE, qcol = NULL, scol = NULL, type = 'any', by = NULL, return.type = 'same', max.chunk = 1e13, verbose = FALSE, mc.cores = 1, maxgap = -1L, ...)
 {
 
     subject.id = query.id = i.start = i.end = NULL ## for NOTE
@@ -2692,14 +2692,14 @@ gr.findoverlaps = function(query, subject, ignore.strand = TRUE, first = FALSE, 
     }
 
     ## perform the actual overlaps
-    h <- tryCatch(GenomicRanges::findOverlaps(query, subject, type = type, ignore.strand = ignore.strand, ...), error = function(e) NULL)
+    h <- tryCatch(GenomicRanges::findOverlaps(query, subject, type = type, ignore.strand = ignore.strand, maxgap = maxgap, ...), error = function(e) NULL)
     ## if any seqlengths badness happens overrride
     if (is.null(h))
     {
         warning('seqlength mismatch .. no worries, just letting you know')
         query = gr.fix(query, subject)
         subject = gr.fix(subject, query)
-        h <- GenomicRanges::findOverlaps(query, subject, type = type, ignore.strand = ignore.strand, ...)
+        h <- GenomicRanges::findOverlaps(query, subject, type = type, ignore.strand = ignore.strand, maxgap = maxgap, ...)
     }
 
     r <- ranges(h, ranges(query), ranges(subject))

--- a/R/gUtils.R
+++ b/R/gUtils.R
@@ -2073,7 +2073,7 @@ rle.query = function(subject.rle, query.gr, chunksize = 1e9, mc.cores = 1, verbo
 #' @param ... Additional parameters to be passed on to \code{GenomicRanges::findOverlaps}
 #' @return boolean vector of match status
 #' @export
-grl.in = function(grl, windows, some = FALSE, only = FALSE, logical = TRUE, exact = FALSE, ignore.strand = TRUE, ...)
+grl.in = function(grl, windows, some = FALSE, only = FALSE, logical = TRUE, exact = FALSE, ignore.strand = TRUE, maxgap = -1L, ...)
 {
     grl.iid = grl.id = NULL ## for getting past NOTE
 
@@ -2102,7 +2102,7 @@ grl.in = function(grl, windows, some = FALSE, only = FALSE, logical = TRUE, exac
     gr = grl.unlist(grl)
     if (logical)
     {
-        h = tryCatch(GenomicRanges::findOverlaps(gr, windows, ignore.strand = ignore.strand, ...), error = function(e) NULL)
+        h = tryCatch(GenomicRanges::findOverlaps(gr, windows, ignore.strand = ignore.strand, maxgap = maxgap,...), error = function(e) NULL)
         if (!is.null(h)){
             m = data.table(query.id = queryHits(h), subject.id = subjectHits(h))
         }


### PR DESCRIPTION
set the default parameter `maxgap = -1L` in `gr.findoverlaps` and passed it explicitly to the calls of `GenomicRanges::findOverlap`