### PR TITLE
Fixes `gr.val` bug on empty intersection

### DIFF
--- a/R/gUtils.R
+++ b/R/gUtils.R
@@ -1770,8 +1770,14 @@ gr.val = function(query, target, val = NULL, mean = TRUE, weighted = mean, na.rm
                     colnames(values(query)) = new.names
                 }
             } else{
-                for (val in levels(factor(subject$by))){
-                    values(query)[, val] = NA
+                if(is.null(by.prefix)){
+                    for (val in levels(factor(values(target)[, by]))){
+                        values(query)[, val] = NA
+                    }
+                } else {
+                    for (val in levels(factor(values(target)[, by]))){
+                        values(query)[, paste(by.prefix, val, sep='.')] = NA
+                    }
                 }
             }
         }

--- a/tests/testthat/test_rangeops.R
+++ b/tests/testthat/test_rangeops.R
@@ -523,6 +523,8 @@ test_that("gr.tile.map", {
 test_that("gr.val", {
 
     gr = GRanges(1, IRanges(1e6, 2e6))
+    gr2 <- GRanges(1, IRanges(c(1, 300, 5000), c(50, 500, 5600)), 
+                   transcript_type = c("mRNA", "snoRNA", "lncRNA"))
     expect_equal(colnames(mcols(gr.val(gr, example_genes, val = 'name'))), "name")
     ## check val = NULL
     expect_equal(width(gr.val(gr, example_genes)), 1000001)
@@ -552,7 +554,13 @@ test_that("gr.val", {
     expect_equal(width(gr.val(gr, example_genes, val=NULL)), 1000001)
     ## check 'if (inherits(target, 'GRangesList'))''
     ## I get errors: e.g. 'gr.val(grl1, example_genes)'
-
+    ## check empty non-overlapping case transfers levels to columns
+    expect_identical(mcols(gr.val(gr, gr2, by = 'type', by.prefix = NULL)),
+                     DataFrame(lncRNA=NA, mRNA=NA, snoRNA=NA))
+    ## check empyt non-overlapping case with by.prefix
+    expect_identical(mcols(gr.val(gr, gr2, by = 'type', by.prefix = "tx_type")),
+                     DataFrame(tx_type.lncRNA=NA, tx_type.mRNA=NA, tx_type.snoRNA=NA))
+    
 })
 
 


### PR DESCRIPTION
There is [a reference to an undefined variable `subject`](https://github.com/mskilab/gUtils/blob/f8c2fc0c5db6fd55952ea61565caacdb0156dda5/R/gUtils.R#L1773) in the `gr.val` method.  This particular part of the code only gets visited when `by` is defined and the intersection between the GRange objects is empty.  This pull request fixes this bug and adds two unit tests to ensure this case is covered, considering both with and without `by.prefix = NULL`.