### PR TITLE
Changing pad in anchorlift -- midpoint of subject range

### DIFF
--- a/R/gUtils.R
+++ b/R/gUtils.R
@@ -3968,7 +3968,7 @@ anchorlift = function(query, subject, window = 1e9, by = NULL, seqname = "Anchor
     }
     
     ## new coordinate is query relative to <midpoint> of subject   
-    pad = (start(subject)[ov$subject.id] + round(width(subject)[ov$subject.id]/2) + round(width(query)[ov$query.id]/2))
+    pad = start(subject)[ov$subject.id] + round(width(subject)[ov$subject.id]/2)
     nov = GRanges(seqnames(query)[ov$query.id], IRanges(start(query)[ov$query.id]-pad, end(query)[ov$query.id]-pad),
                   strand = strand(query)[ov$query.id])
 


### PR DESCRIPTION
The existing pad to adjust coordinates of anchor-lifted ranges erroneously adjusts by the width of the query range, such that the start positions of the queries end up where the midpoints should be.

Note difference in behavior:
```
library(devtools)
library(gUtils)

## define 2 dummy GRanges with the same coordinates
## expected behavior of lifting one anchored around the other would be a range centered at 0
a = GRanges(1, IRanges(500, width=20))
b = GRanges(1, IRanges(500, width=20))
anchorlift(a, b)

devtools::source_url('https://raw.githubusercontent.com/mskilab/gUtils/julie/R/gUtils.R')
anchorlift(a, b)
```
