### PR TITLE
Remove strand from strand-agnostic overlap counting

### DIFF
--- a/R/gUtils.R
+++ b/R/gUtils.R
@@ -3402,7 +3402,7 @@ setGeneric('%O%', function(x, ...) standardGeneric('%O%'))
 setMethod("%O%", signature(x = "GRanges"), function(x, y) {
 
     query.id = NULL; ## NOTE fix
-    ov = gr2dt(gr.findoverlaps(x, reduce(y)))
+    ov = gr2dt(gr.findoverlaps(x, reduce(gr.stripstrand(y))))
     if (nrow(ov) > 0) {
         ov = ov[ , sum(width), keyby = query.id]
         x$width.ov = 0
@@ -3467,7 +3467,7 @@ setMethod("%OO%", signature(x = "GRanges"), function(x, y) {
 setGeneric('%o%', function(x, ...) standardGeneric('%o%'))
 setMethod("%o%", signature(x = "GRanges"), function(x, y) {
     query.id = NULL; ## NOTE fix
-    ov = gr2dt(gr.findoverlaps(x, reduce(y)))
+    ov = gr2dt(gr.findoverlaps(x, reduce(gr.stripstrand(y))))
     if (nrow(ov)>0){
         ov = ov[ , sum(width), keyby = query.id]
         x$width.ov = 0


### PR DESCRIPTION
The strand-agnostic overlap counting methods `%O%` and `%o%` rely on `reduce`, which is not strand agnostic, and therefore double-count overlaps from ranges in `b` if `b` has overlapping ranges on opposite strands. The output numeric vector therefore can take values from `[0, 2]` for `%O%` and `[0, 2*width]` for `%o%`.

eg:
```
library(devtools)
library(gUtils)

a = GRanges(1, IRanges(1, 300), strand="*")
b = GRanges(1, IRanges(c(1, 101), width=200), strand=c("+", "-"))

a %O% b
```
[1] 1.333333
```
a %o% b
```
[1] 400
```
source_url('https://raw.githubusercontent.com/mskilab/gUtils/overlap_bases/R/gUtils.R')
a %O% b
```
[1] 1
```
a %o% b
```
[1] 300