### PR TITLE
fixing grl.in with newest version of R, and adding stranded gr.tile

### DIFF
--- a/R/gUtils.R
+++ b/R/gUtils.R
@@ -2123,7 +2123,6 @@ grl.in = function(grl, windows, some = FALSE, only = FALSE, logical = TRUE, exac
 
     m$grl.id = gr$grl.ix[m$query.id]
     m$grl.iid = gr$grl.iix[m$query.id]
-
     if (some){
         tmp = as.data.frame(m[, length(unique(grl.iid)), by = grl.id])
     }
@@ -2133,7 +2132,7 @@ grl.in = function(grl, windows, some = FALSE, only = FALSE, logical = TRUE, exac
                             split(m$query.id, factor(m$grl.id, 1:length(grl)))))
     }
     else{
-        tmp = stats::aggregate(formula = subject.id ~ grl.id, data = m, FUN = function(x) numwin-length(setdiff(1:numwin, x)))
+        tmp = stats::aggregate(x = subject.id ~ grl.id, data = m, FUN = function(x) numwin-length(setdiff(1:numwin, x)))
     }
 
     out = rep(FALSE, length(grl))

--- a/R/gUtils.R
+++ b/R/gUtils.R
@@ -1408,6 +1408,7 @@ gr.pairflip = function(gr)
 #'
 #' @param gr \code{GRanges}, \code{seqlengths} or \code{Seqinfo} range to tile. If has \code{GRanges} has overlaps, will reduce first.
 #' @param width integer Width of each tile (default = 1e3)
+#' @param stranded boolean Whether to reverse order of tiles on negative strand (default = FALSE)
 #' @examples
 #'
 #' ## 10 tiles of width 10
@@ -1418,7 +1419,7 @@ gr.pairflip = function(gr)
 #'
 #' @return GRanges with tiled intervals
 #' @export
-gr.tile = function(gr, width = 1e3)
+gr.tile = function(gr, width = 1e3, stranded = FALSE)
 {
     numw = tile.id = query.id = NULL ## getting past NOTE
     if (is(gr, 'data.table')){
@@ -1441,8 +1442,14 @@ gr.tile = function(gr, width = 1e3)
     st = rep(start(gr), ws)
     en = rep(end(gr), ws)
     strand = rep(as.character(strand(gr)), ws)
-    dt = data.table(query.id = rep(1:length(gr), ws), tile.id = 1:sum(ws))
-    dt[, numw := 0:(length(tile.id)-1), by = query.id]
+    if(stranded){
+        dt = data.table(query.id = rep(1:length(gr), ws), tile.id = 1:sum(ws),strand=strand)
+        dt[strand=='+', numw := 0:(length(tile.id)-1), by = query.id]
+        dt[strand=='-', numw := rev(0:(length(tile.id)-1)), by = query.id]
+    }else{
+        dt = data.table(query.id = rep(1:length(gr), ws), tile.id = 1:sum(ws))
+        dt[, numw := 0:(length(tile.id)-1), by = query.id]
+    }
     start = pmin(st+width*dt$numw, en)
     end = pmin(st+width*(dt$numw+1)-1, en)
 

--- a/R/gUtils.R
+++ b/R/gUtils.R
@@ -2104,7 +2104,6 @@ grl.in = function(grl, windows, some = FALSE, only = FALSE, logical = TRUE, exac
 
     m$grl.id = gr$grl.ix[m$query.id]
     m$grl.iid = gr$grl.iix[m$query.id]
-
     if (some){
         tmp = as.data.frame(m[, length(unique(grl.iid)), by = grl.id])
     }
@@ -2114,7 +2113,7 @@ grl.in = function(grl, windows, some = FALSE, only = FALSE, logical = TRUE, exac
                             split(m$query.id, factor(m$grl.id, 1:length(grl)))))
     }
     else{
-        tmp = stats::aggregate(formula = subject.id ~ grl.id, data = m, FUN = function(x) numwin-length(setdiff(1:numwin, x)))
+        tmp = stats::aggregate(x = subject.id ~ grl.id, data = m, FUN = function(x) numwin-length(setdiff(1:numwin, x)))
     }
 
     out = rep(FALSE, length(grl))


### PR DESCRIPTION
added some functionality to gr.tile so it tiles backwards along negative strand if the flag "stranded = TRUE" is called

Also modified a line inside the function grl.in which calls "aggregate", which broke when porting to 4.3.2. 